### PR TITLE
feat: add optional time crate support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "1.0.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93be0eb33b912f5e66004d0b756423c285273259068b1c80a71d7842658189b"
 dependencies = [
- "apalis-core",
+ "apalis-core 1.0.0-rc.1",
  "futures-util",
  "pin-project",
  "thiserror",
@@ -37,9 +37,27 @@ version = "0.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a5ed6bb8e64c360ed4ad666a6cbc42e9e6df73087461dc4071f510a3af284637"
 dependencies = [
- "apalis-core",
+ "apalis-core 1.0.0-rc.1",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "apalis-core"
+version = "1.0.0-beta.2"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -63,12 +81,9 @@ dependencies = [
 
 [[package]]
 name = "apalis-sql"
-version = "1.0.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ade5d8faa60e9975b01d3bb1ebc5028589aa4986365eaa4d080d30ed3b5141f"
+version = "1.0.0-beta.2"
 dependencies = [
- "apalis-core",
- "chrono",
+ "apalis-core 1.0.0-beta.2",
  "serde",
  "serde_json",
  "thiserror",
@@ -80,7 +95,7 @@ version = "1.0.0-rc.1"
 dependencies = [
  "apalis",
  "apalis-codec",
- "apalis-core",
+ "apalis-core 1.0.0-beta.2",
  "apalis-sql",
  "apalis-workflow",
  "async-std",
@@ -93,6 +108,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "thiserror",
+ "time",
  "tokio",
  "ulid",
 ]
@@ -103,7 +119,7 @@ version = "0.1.0-rc.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc024da2d5d3ab59cc9fea099a2e2b20de5ff608f2e287abcb73aa45e4966a89"
 dependencies = [
- "apalis-core",
+ "apalis-core 1.0.0-rc.1",
  "futures",
  "petgraph",
  "serde",
@@ -462,6 +478,16 @@ dependencies = [
  "const-oid",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+dependencies = [
+ "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -1201,6 +1227,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1445,6 +1477,12 @@ checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1894,6 +1932,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "thiserror",
+ "time",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1979,6 +2018,7 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror",
+ "time",
  "tracing",
  "whoami",
 ]
@@ -2017,6 +2057,7 @@ dependencies = [
  "sqlx-core",
  "stringprep",
  "thiserror",
+ "time",
  "tracing",
  "whoami",
 ]
@@ -2042,6 +2083,7 @@ dependencies = [
  "serde_urlencoded",
  "sqlx-core",
  "thiserror",
+ "time",
  "tracing",
  "url",
 ]
@@ -2128,6 +2170,37 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,30 +11,33 @@ keywords = ["apalis", "background-jobs", "task-queue", "sqlite", "async"]
 categories = ["asynchronous", "database"]
 
 [features]
-default = ["tokio-comp", "migrate", "json"]
+default = ["tokio-comp", "migrate", "json", "chrono"]
 migrate = ["sqlx/migrate", "sqlx/macros"]
 async-std-comp = ["async-std", "sqlx/runtime-async-std-rustls"]
 async-std-comp-native-tls = ["async-std", "sqlx/runtime-async-std-native-tls"]
 tokio-comp = ["tokio", "sqlx/runtime-tokio-rustls"]
 tokio-comp-native-tls = ["tokio", "sqlx/runtime-tokio-native-tls"]
 json = ["apalis-codec/json", "sqlx/json"]
+chrono = ["dep:chrono", "sqlx/chrono"]
+time = ["dep:time", "sqlx/time"]
 
 [dependencies.sqlx]
 version = "0.8.6"
 default-features = false
-features = ["chrono", "sqlite"]
+features = ["sqlite"]
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
 apalis-codec = { version = "0.1.0-rc.1", default-features = false }
-apalis-core = { version = "1.0.0-rc.1", features = ["sleep"] }
-apalis-sql = { version = "1.0.0-rc.1" }
+apalis-core = { path = "../apalis/apalis-core", features = ["sleep"] }
+apalis-sql = { path = "../apalis/apalis-sql", default-features = false }
 log = "0.4.21"
 futures = "0.3.30"
 tokio = { version = "1", features = ["rt", "net"], optional = true }
 async-std = { version = "1.13.0", optional = true }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"], optional = true }
+time = { version = "0.3", features = ["serde"], optional = true }
 thiserror = "2.0.0"
 pin-project = "1.1.10"
 ulid = { version = "1", features = ["serde"] }
@@ -69,3 +72,12 @@ needless_pass_by_ref_mut = "warn"
 needless_pass_by_value = "warn"
 option_option = "warn"
 redundant_clone = "warn"
+
+[package.metadata.cargo-udeps.ignore]
+# When both chrono and time features are enabled, time takes precedence
+# so chrono appears unused. This is expected behavior for --all-features.
+normal = ["chrono"]
+
+[patch.crates-io]
+apalis-core = { path = "../apalis/apalis-core" }
+apalis-sql = { path = "../apalis/apalis-sql" }

--- a/src/fetcher.rs
+++ b/src/fetcher.rs
@@ -12,6 +12,8 @@ use apalis_core::{
     worker::context::WorkerContext,
 };
 use apalis_sql::from_row::TaskRow;
+
+use crate::SqliteDateTime;
 use futures::{FutureExt, future::BoxFuture, stream::Stream};
 use pin_project::pin_project;
 use sqlx::{Pool, Sqlite, SqlitePool};
@@ -41,7 +43,7 @@ where
     .await?
     .into_iter()
     .map(|r| {
-        let row: TaskRow = r.try_into()?;
+        let row: TaskRow<SqliteDateTime> = r.try_into()?;
         row.try_into_task_compact()
             .map_err(|e| sqlx::Error::Protocol(e.to_string()))
     })

--- a/src/from_row.rs
+++ b/src/from_row.rs
@@ -1,4 +1,4 @@
-use chrono::{TimeZone, Utc};
+use crate::SqliteDateTime;
 
 #[derive(Debug)]
 pub(crate) struct SqliteTaskRow {
@@ -17,10 +17,16 @@ pub(crate) struct SqliteTaskRow {
     pub(crate) metadata: Option<String>,
 }
 
-impl TryInto<apalis_sql::from_row::TaskRow> for SqliteTaskRow {
+/// Convert a UNIX timestamp to SqliteDateTime
+fn unix_to_datetime(ts: i64) -> Result<SqliteDateTime, sqlx::Error> {
+    SqliteDateTime::from_unix_timestamp(ts)
+        .ok_or_else(|| sqlx::Error::Protocol("Invalid timestamp".into()))
+}
+
+impl TryInto<apalis_sql::from_row::TaskRow<SqliteDateTime>> for SqliteTaskRow {
     type Error = sqlx::Error;
 
-    fn try_into(self) -> Result<apalis_sql::from_row::TaskRow, Self::Error> {
+    fn try_into(self) -> Result<apalis_sql::from_row::TaskRow<SqliteDateTime>, Self::Error> {
         Ok(apalis_sql::from_row::TaskRow {
             job: self.job,
             id: self
@@ -37,28 +43,13 @@ impl TryInto<apalis_sql::from_row::TaskRow> for SqliteTaskRow {
                 .ok_or_else(|| sqlx::Error::Protocol("Missing attempts".into()))?
                 as usize,
             max_attempts: self.max_attempts.map(|v| v as usize),
-            run_at: self.run_at.map(|ts| {
-                Utc.timestamp_opt(ts, 0)
-                    .single()
-                    .ok_or_else(|| sqlx::Error::Protocol("Invalid run_at timestamp".into()))
-                    .unwrap()
-            }),
+            run_at: self.run_at.map(unix_to_datetime).transpose()?,
             last_result: self
                 .last_result
                 .map(|res| serde_json::from_str(&res).unwrap_or(serde_json::Value::Null)),
-            lock_at: self.lock_at.map(|ts| {
-                Utc.timestamp_opt(ts, 0)
-                    .single()
-                    .ok_or_else(|| sqlx::Error::Protocol("Invalid run_at timestamp".into()))
-                    .unwrap()
-            }),
+            lock_at: self.lock_at.map(unix_to_datetime).transpose()?,
             lock_by: self.lock_by,
-            done_at: self.done_at.map(|ts| {
-                Utc.timestamp_opt(ts, 0)
-                    .single()
-                    .ok_or_else(|| sqlx::Error::Protocol("Invalid run_at timestamp".into()))
-                    .unwrap()
-            }),
+            done_at: self.done_at.map(unix_to_datetime).transpose()?,
             priority: self.priority.map(|v| v as usize),
             metadata: self
                 .metadata

--- a/src/queries/fetch_by_id.rs
+++ b/src/queries/fetch_by_id.rs
@@ -5,7 +5,9 @@ use apalis_core::{
 use apalis_sql::from_row::{FromRowError, TaskRow};
 use ulid::Ulid;
 
-use crate::{CompactType, SqliteContext, SqliteStorage, SqliteTask, from_row::SqliteTaskRow};
+use crate::{
+    CompactType, SqliteContext, SqliteDateTime, SqliteStorage, SqliteTask, from_row::SqliteTaskRow,
+};
 
 impl<Args, D, F> FetchById<Args> for SqliteStorage<Args, D, F>
 where
@@ -30,7 +32,7 @@ where
                 .fetch_optional(&pool)
                 .await?
                 .map(|r| {
-                    let row: TaskRow = r
+                    let row: TaskRow<SqliteDateTime> = r
                         .try_into()
                         .map_err(|e: sqlx::Error| FromRowError::DecodeError(e.into()))?;
                     row.try_into_task_compact().and_then(|t| {

--- a/src/queries/list_tasks.rs
+++ b/src/queries/list_tasks.rs
@@ -5,7 +5,9 @@ use apalis_core::{
 use apalis_sql::from_row::{FromRowError, TaskRow};
 use ulid::Ulid;
 
-use crate::{CompactType, SqliteContext, SqliteStorage, SqliteTask, from_row::SqliteTaskRow};
+use crate::{
+    CompactType, SqliteContext, SqliteDateTime, SqliteStorage, SqliteTask, from_row::SqliteTaskRow,
+};
 
 impl<Args, D, F> ListTasks<Args> for SqliteStorage<Args, D, F>
 where
@@ -46,7 +48,7 @@ where
             .await?
             .into_iter()
             .map(|r| {
-                let row: TaskRow = r
+                let row: TaskRow<SqliteDateTime> = r
                     .try_into()
                     .map_err(|e: sqlx::Error| FromRowError::DecodeError(e.into()))?;
                 row.try_into_task_compact().and_then(|t| {
@@ -95,7 +97,7 @@ where
             .await?
             .into_iter()
             .map(|r| {
-                let row: TaskRow = r.try_into()?;
+                let row: TaskRow<SqliteDateTime> = r.try_into()?;
                 row.try_into_task_compact()
                     .map_err(|e| sqlx::Error::Protocol(e.to_string()))
             })

--- a/src/queries/wait_for.rs
+++ b/src/queries/wait_for.rs
@@ -22,7 +22,7 @@ where
     Self: BackendExt<IdType = Ulid, Codec = Decode, Error = sqlx::Error, Compact = CompactType>,
     Result<O, String>: DeserializeOwned,
 {
-    type ResultStream = BoxStream<'static, Result<TaskResult<O, Ulid>, Self::Error>>;
+    type ResultStream = BoxStream<'static, Result<TaskResult<O>, Self::Error>>;
     fn wait_for(
         &self,
         task_ids: impl IntoIterator<Item = TaskId<Self::IdType>>,
@@ -78,7 +78,7 @@ where
     fn check_status(
         &self,
         task_ids: impl IntoIterator<Item = TaskId<Self::IdType>> + Send,
-    ) -> impl Future<Output = Result<Vec<TaskResult<O, Ulid>>, Self::Error>> + Send {
+    ) -> impl Future<Output = Result<Vec<TaskResult<O>>, Self::Error>> + Send {
         let pool = self.pool.clone();
         let ids: Vec<String> = task_ids.into_iter().map(|id| id.to_string()).collect();
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,0 +1,65 @@
+use apalis_sql::SqlTimestamp;
+
+// ============================================================================
+// Chrono implementation
+// ============================================================================
+
+#[cfg(all(feature = "chrono", not(feature = "time")))]
+mod inner {
+    use super::*;
+    use chrono::{DateTime, TimeZone, Utc};
+
+    /// Public newtype wrapper - implements SqlTimestamp for TaskRow<SqliteDateTime>
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct SqliteDateTime(pub DateTime<Utc>);
+
+    impl SqlTimestamp for SqliteDateTime {
+        fn to_unix_timestamp(&self) -> i64 {
+            self.0.timestamp()
+        }
+    }
+
+    impl SqliteDateTime {
+        /// Create from unix timestamp
+        pub fn from_unix_timestamp(ts: i64) -> Option<Self> {
+            Utc.timestamp_opt(ts, 0).single().map(Self)
+        }
+    }
+}
+
+// ============================================================================
+// Time implementation
+// ============================================================================
+
+#[cfg(feature = "time")]
+mod inner {
+    use super::*;
+    use time::OffsetDateTime;
+
+    /// Public newtype wrapper - implements SqlTimestamp for TaskRow<SqliteDateTime>
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct SqliteDateTime(pub OffsetDateTime);
+
+    impl SqlTimestamp for SqliteDateTime {
+        fn to_unix_timestamp(&self) -> i64 {
+            self.0.unix_timestamp()
+        }
+    }
+
+    impl SqliteDateTime {
+        /// Create from unix timestamp
+        pub fn from_unix_timestamp(ts: i64) -> Option<Self> {
+            OffsetDateTime::from_unix_timestamp(ts).ok().map(Self)
+        }
+    }
+}
+
+// ============================================================================
+// Re-exports
+// ============================================================================
+
+#[cfg(any(feature = "chrono", feature = "time"))]
+pub use inner::SqliteDateTime;
+
+#[cfg(not(any(feature = "chrono", feature = "time")))]
+compile_error!("Either 'chrono' or 'time' feature must be enabled");


### PR DESCRIPTION
## Summary
- Adds `SqliteDateTime` wrapper implementing `SqlTimestamp`
- Enables optional `time` crate support alongside default `chrono`

Ref: apalis-dev/apalis#654, apalis-dev/apalis#649